### PR TITLE
feat:支持设置单个实例拦截器/静态方法全局设置token

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Http.getInstances("https://www.example.com");
 ```
 
 ```js
-setReqInterceptor (resolve?:(config:AxiosRequestConfig) => AxiosRequestConfig, reject?:(error:any) => void, key?:string)
+setReqInterceptor (resolve?:(config:AxiosRequestConfig) => AxiosRequestConfig, reject?:(error:any) => void, url?:string)
 ```
 
 设置全局请求拦截器
@@ -81,7 +81,7 @@ Http.setReqInterceptor(
 ```
 
 ```js
-setResInterceptor (resolve?:(res:AxiosResponse) => AxiosResponse, reject?:(error) => any, key?:string)
+setResInterceptor (resolve?:(res:AxiosResponse) => AxiosResponse, reject?:(error) => any, url?:string)
 ```
 
 设置全局响应拦截器

--- a/README.md
+++ b/README.md
@@ -1,154 +1,240 @@
 ## 介绍
-对axios做了二次封装，统一axios的配置
+
+对 axios 做了二次封装，统一 axios 的配置
+
 ## 安装
-使用npm
+
+使用 npm
+
 ```
 npm install mlz-axios
 ```
-使用yarn
+
+使用 yarn
+
 ```
 yarn add mlz-axios
 ```
-## 默认axios配置
+
+## 默认 axios 配置
+
+```js
+timeout: 5000;
+withCredentials: true;
+validateStatus: status => status >= 200 && status < 599;
 ```
-timeout: 5000
-withCredentials: true
-validateStatus: status => status >= 200 && status < 599
-```
+
 ## 实例化
-实例化可以传入baseUrl和默认配置
-```
+
+实例化可以传入 baseUrl 和默认配置
+
+```js
 import Http from 'mlz-axios'
 const httpIns = new Http(baseUrl:string, config:AxiosRequestConfig)
 ```
+
 ## 静态方法
-### getInstances(key)
+
+```js
+getInstances(key:string)
+```
+
 获取对应的实例
+
+```js
+import Http from "mlz-axios";
+Http.getInstances("https://www.example.com");
 ```
-import Http from 'mlz-axios'
-Http.getInstances('https://www.example.com')
+
+```js
+setReqInterceptor (resolve?:(config:AxiosRequestConfig) => AxiosRequestConfig, reject?:(error:any) => void, key?:string)
 ```
-### setReqInterceptor(resolve, reject)
+
 设置全局请求拦截器
+
+```js
+import Http from "mlz-axios";
+Http.setReqInterceptor(
+  config => {
+    console.log(config);
+  },
+  err => {
+    console.log(err);
+  }
+);
 ```
-import Http from 'mlz-axios'
-Http.setReqInterceptor((config) => {
-  console.log(config)
-}, (err) => {
-  console.log(err)
-})
+
+设置单个实例请求拦截器
+
+```js
+Http.setReqInterceptor(
+  config => {
+    console.log("请求前config", config);
+    return config;
+  },
+  err => {
+    console.log("请求前err", err);
+    return Promise.reject(err);
+  },
+  "https://xxx.xxx.com"
+);
 ```
-### setResInterceptor(resolve, reject)
+
+```js
+setResInterceptor (resolve?:(res:AxiosResponse) => AxiosResponse, reject?:(error) => any, key?:string)
+```
+
 设置全局响应拦截器
+
+```js
+Http.setResInterceptor(
+  res => {
+    console.log("请求后res", res);
+    return res;
+  },
+  err => {
+    console.log("请求后err", err);
+    return Promise.reject(err);
+  }
+);
 ```
-import Http from 'mlz-axios'
-Http.setResInterceptor((response) => {
-  console.log(response)
-}, (err) => {
-  console.log(err)
-})
+
+设置单个实例响应拦截器
+
+```js
+Http.setResInterceptor(
+  res => {
+    console.log("请求后res", res);
+    return res;
+  },
+  err => {
+    console.log("请求后err", err);
+    return Promise.reject(err);
+  },
+  "https://xxx.xxx.com"
+);
 ```
+
 ## 实例方法
-### setAuthorizationTypeOrToken(type, token)
-设置authorizationToken和authorizationType
+
+```js
+setAuthorizationTypeOrToken(typeKey:string, typeValue:number, tokenKey:string, tokenValue:string)
 ```
-import Http from 'mlz-axios'
-const httpIns = new Http('https://www.example.com')
-httpIns.setAuthorizationTypeOrToken(1, 'token')
+
+设置 authorizationToken 和 authorizationType
+
+```js
+import Http from "mlz-axios";
+const token = "xxx";
+const type = 3;
+Http.setAuthorizationTypeOrToken("authorization_type", type, "Authorization", token);
 ```
+
 ### get(url[, config])
-```
-import Http from 'mlz-axios'
-const httpIns = new Http('https://www.example.com')
-httpIns.get('/user')
-  .then(function (response) {
+
+```js
+import Http from "mlz-axios";
+const httpIns = new Http("https://www.example.com");
+httpIns
+  .get("/user")
+  .then(function(response) {
     // handle success
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     // handle error
     console.log(error);
   })
-  .finally(function () {
+  .finally(function() {
     // always executed
   });
 ```
+
 ### delete(url[, config])
-```
-import Http from 'mlz-axios'
-const httpIns = new Http('https://www.example.com')
-httpIns.delete('/user')
-  .then(function (response) {
+
+```js
+import Http from "mlz-axios";
+const httpIns = new Http("https://www.example.com");
+httpIns
+  .delete("/user")
+  .then(function(response) {
     // handle success
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     // handle error
     console.log(error);
   })
-  .finally(function () {
+  .finally(function() {
     // always executed
   });
 ```
+
 ### post(url[, data[, config]])
-```
-import Http from 'mlz-axios'
-const httpIns = new Http('https://www.example.com')
-httpIns.post('/user', {
-    firstName: 'Fred',
-    lastName: 'Flintstone'
+
+```js
+import Http from "mlz-axios";
+const httpIns = new Http("https://www.example.com");
+httpIns
+  .post("/user", {
+    firstName: "Fred",
+    lastName: "Flintstone"
   })
-  .then(function (response) {
+  .then(function(response) {
     // handle success
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     // handle error
     console.log(error);
   })
-  .finally(function () {
+  .finally(function() {
     // always executed
   });
 ```
+
 ### put(url[, data[, config]])
-```
-import Http from 'mlz-axios'
-const httpIns = new Http('https://www.example.com')
-httpIns.put('/user', {
-    firstName: 'Fred',
-    lastName: 'Flintstone'
+
+```js
+import Http from "mlz-axios";
+const httpIns = new Http("https://www.example.com");
+httpIns
+  .put("/user", {
+    firstName: "Fred",
+    lastName: "Flintstone"
   })
-  .then(function (response) {
+  .then(function(response) {
     // handle success
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     // handle error
     console.log(error);
   })
-  .finally(function () {
+  .finally(function() {
     // always executed
   });
 ```
+
 ### patch(url[, data[, config]])
-```
-import Http from 'mlz-axios'
-const httpIns = new Http('https://www.example.com')
-httpIns.patch('/user', {
-    firstName: 'Fred',
-    lastName: 'Flintstone'
+
+```js
+import Http from "mlz-axios";
+const httpIns = new Http("https://www.example.com");
+httpIns
+  .patch("/user", {
+    firstName: "Fred",
+    lastName: "Flintstone"
   })
-  .then(function (response) {
+  .then(function(response) {
     // handle success
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     // handle error
     console.log(error);
   })
-  .finally(function () {
+  .finally(function() {
     // always executed
   });
 ```
-
-

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,39 +1,46 @@
-import Http from '../src/index'
-Http.setToken(2, 'aaa')
-// Http.setDefaultConf({
-//   headers: {
-//     post: 'application/json'
-//   }
-// })
-Http.setReqInterceptor((config) => {
-  console.log('请求前config', config)
-}, (err) => {
-  console.log('请求前err', err)
-})
-Http.setResInterceptor((res) => {
-  console.log('请求后res', res)
-}, (err) => {
-  console.log('请求前err', err)
-})
-const httpIns = new Http('http://localhost:8080')
-httpIns.post('/base/post',
-  {
-    a: 1,
-    b: 2
-  },
-).then((res) => {
-  console.log(res)
-})
+import Http from "../src/index";
+const token = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0NTAsInVzZXJfdHlwZSI6ImFkbWluIiwianRpIjoiNjVlMTY1NzEtOTliNy00YzBiLTg0ODktYjhiYzNkNTE2ZGY3IiwiaWF0IjoxNTcxMDQyNzM2fQ.cHA8rBDMZFj7P1a6UWKjINtsYOOt77ROAhK0kKZBx6Y'
+const type = 3;
+const httpIns = new Http("https://backend-dev.codemao.cn");
+const httpIns2 = new Http("https://dev-api-crm-codemaster.codemao.cn");
 
-const httpIns1 = new Http('http://localhost:9000')
-httpIns1.get('/error/timeout').then((res) => {
-  console.log(res)
-})
-httpIns.post('/base/post',
-  {
-    a: 1,
-    b: 2
+Http.setAuthorizationTypeOrToken("authorization_type", type, "Authorization", token);
+
+Http.setReqInterceptor(
+  config => {
+    console.log("请求前config", config);
+    return config;
   },
-).then((res) => {
-  console.log(res)
-})
+  err => {
+    console.log("请求前err", err);
+    return Promise.reject(err);
+  },
+  "https://backend-dev.codemao.cn"
+);
+Http.setResInterceptor(
+  res => {
+    console.log("请求后res", res);
+    return res;
+  },
+  err => {
+    console.log("请求后err", err);
+    return Promise.reject(err);
+  }
+);
+
+httpIns
+  .post("/tiger/lesson/ticket/give-out", {
+    amount: "1",
+    student_id: "1000824602",
+    ticket_type: "101"
+  })
+  .then(res => {
+    console.log(res.data);
+  })
+  .catch(err => {
+    console.log(err);
+  });
+
+httpIns2.get("/admin/crm/head-teachers/statistics/card", { params: { card_type: 4 } }).then(res => {
+  console.log(res.data);
+});

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,32 +1,57 @@
 import Http from "../src/index";
-const token = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0NTAsInVzZXJfdHlwZSI6ImFkbWluIiwianRpIjoiNjVlMTY1NzEtOTliNy00YzBiLTg0ODktYjhiYzNkNTE2ZGY3IiwiaWF0IjoxNTcxMDQyNzM2fQ.cHA8rBDMZFj7P1a6UWKjINtsYOOt77ROAhK0kKZBx6Y'
+const token =
+  "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0NTAsInVzZXJfdHlwZSI6ImFkbWluIiwianRpIjoiNjVlMTY1NzEtOTliNy00YzBiLTg0ODktYjhiYzNkNTE2ZGY3IiwiaWF0IjoxNTcxMDQyNzM2fQ.cHA8rBDMZFj7P1a6UWKjINtsYOOt77ROAhK0kKZBx6Y";
 const type = 3;
 const httpIns = new Http("https://backend-dev.codemao.cn");
 const httpIns2 = new Http("https://dev-api-crm-codemaster.codemao.cn");
+const httpIns3 = new Http("https://dev-api-teaching-codemaster.codemao.cn");
 
-Http.setAuthorizationTypeOrToken("authorization_type", type, "Authorization", token);
-
+// Http.setAuthorizationTypeOrToken("authorization_type", type, "Authorization", token);
 Http.setReqInterceptor(
   config => {
-    console.log("请求前config", config);
+    config.headers.Authorization = "codemao_token";
+    config.headers.authorization_type = 4;
     return config;
   },
   err => {
-    console.log("请求前err", err);
     return Promise.reject(err);
   },
-  "https://backend-dev.codemao.cn"
+  "https://dev-api-teaching-codemaster.codemao.cn"
 );
-Http.setResInterceptor(
-  res => {
-    console.log("请求后res", res);
-    return res;
+
+Http.setReqInterceptor(
+  config => {
+    config.headers.Authorization = token;
+    config.headers.authorization_type = 3;
+    return config;
   },
   err => {
-    console.log("请求后err", err);
     return Promise.reject(err);
   }
 );
+
+console.log(Http.INSTANCES_REQUEST_INTERCEPTORS);
+
+Http.setResInterceptor(
+  res => {
+    console.log("https://dev-api-teaching-codemaster.codemao.cn");
+  },
+  err => {
+    return Promise.reject(err);
+  },
+  "https://dev-api-teaching-codemaster.codemao.cn"
+);
+
+Http.setResInterceptor(
+  res => {
+    console.log("common");
+  },
+  err => {
+    return Promise.reject(err);
+  }
+);
+
+console.log(Http.INSTANCES_RESPONSE_INTERCEPTORS);
 
 httpIns
   .post("/tiger/lesson/ticket/give-out", {
@@ -34,13 +59,16 @@ httpIns
     student_id: "1000824602",
     ticket_type: "101"
   })
-  .then(res => {
-    console.log(res.data);
-  })
+  .then(res => {})
   .catch(err => {
     console.log(err);
   });
 
-httpIns2.get("/admin/crm/head-teachers/statistics/card", { params: { card_type: 4 } }).then(res => {
-  console.log(res.data);
-});
+// httpIns2.setInstancesAuthorizationTypeOrToken("type", 4, "token", "Bearer");
+
+httpIns2
+  .get("/admin/crm/head-teachers/statistics/card", { params: { card_type: 4 } })
+  .then(res => {});
+
+// httpIns3.setInstancesAuthorizationTypeOrToken("type", 1, "token", "xxx");
+httpIns3.get("/teachers/track").then(res => {});

--- a/src/mlz_axios.ts
+++ b/src/mlz_axios.ts
@@ -1,6 +1,6 @@
-import axios, { 
-  AxiosRequestConfig, 
-  CancelTokenStatic, 
+import axios, {
+  AxiosRequestConfig,
+  CancelTokenStatic,
   CancelTokenSource,
   AxiosPromise,
   AxiosResponse,
@@ -14,35 +14,37 @@ const DEFAULT_CONFIG:AxiosRequestConfig = {
 }
 
 export class Http {
-  authorizationType;
-  authorizationToken:string = '';
-  cancelToken:CancelTokenStatic = axios.CancelToken;
-  source:CancelTokenSource = this.cancelToken.source();
-  public axiosIns:AxiosInstance;
-  static INSTANCES:{[key:string]: AxiosInstance} = {};
-  constructor(baseUrl:string, config:AxiosRequestConfig = {}) {
+  private cancelToken: CancelTokenStatic = axios.CancelToken;
+  private source: CancelTokenSource = this.cancelToken.source();
+  private axiosIns: AxiosInstance;
+
+  static authorizationTypeKey:string = 'Authorization';
+  static authorizationTokenKey:string = 'authorization_type';
+  static authorizationType:number;
+  static authorizationToken: string = "";
+  static INSTANCES: { [key: string]: AxiosInstance } = {};
+
+  constructor(baseUrl: string, config: AxiosRequestConfig = {}) {
     const axiosIns = axios.create({
       baseURL: baseUrl,
       ...DEFAULT_CONFIG,
-      ...config,
+      ...config
     });
     Http.INSTANCES[baseUrl] = axiosIns;
     this.axiosIns = axiosIns;
   }
-  setAuthorizationTypeOrToken(type, token) {
-    this.authorizationToken = token;
-    this.authorizationType = type;
-  }
-  public request(opt:AxiosRequestConfig) {
-    const _opt = Object.assign(null, opt);
+
+  private request(opt: AxiosRequestConfig) {
+    const _opt = Object.assign({}, opt);
     _opt.headers = {
       ..._opt.headers,
-      authorization_type: this.authorizationType,
-      authorization_token: this.authorizationToken,
+      [Http.authorizationTypeKey]: Http.authorizationType,
+      [Http.authorizationTokenKey]: Http.authorizationToken
     };
     _opt.cancelToken = this.source.token;
     return this.axiosIns.request(_opt);
   }
+
   public abort() {
     this.source.cancel('API abort.')
   }
@@ -58,9 +60,6 @@ export class Http {
       method: 'post',
       url,
       data,
-      headers: {
-        'Content-type': 'application/x-www-form-urlencoded'
-      },
       ...configs,
     })
   }
@@ -88,20 +87,38 @@ export class Http {
     })
   }
   // 下面是静态方法
+  static setAuthorizationTypeOrToken(typeKey:string, typeValue:number, tokenKey:string, tokenValue:string) {
+    Http.authorizationTypeKey = typeKey;
+    Http.authorizationTokenKey = tokenKey;
+    Http.authorizationToken = tokenValue;
+    Http.authorizationType = typeValue;
+  }
+
   static getInstances(key:string) : AxiosInstance {
     return Http.INSTANCES[key];
   }
-  static setReqInterceptor (resolve?:(config:AxiosRequestConfig) => AxiosRequestConfig, reject?:(error:any) => void) {
-    for (let key in Http.INSTANCES) {
+
+  static setReqInterceptor (resolve?:(config:AxiosRequestConfig) => AxiosRequestConfig, reject?:(error:any) => void, key?:string) {
+    if(key) {
       const instance = Http.INSTANCES[key];
       instance.interceptors.request.use(resolve, reject);
+    } else {
+      for (let key in Http.INSTANCES) {
+        const instance = Http.INSTANCES[key];
+        instance.interceptors.request.use(resolve, reject);
+      }
     }
   }
-  static setResInterceptor (resolve?:(res:AxiosResponse) => AxiosResponse, reject?:(error) => any) {
-    for (let key in Http.INSTANCES) {
+
+  static setResInterceptor (resolve?:(res:AxiosResponse) => AxiosResponse, reject?:(error) => any, key?:string) {
+    if(key) {
       const instance = Http.INSTANCES[key];
       instance.interceptors.response.use(resolve, reject);
+    } else {
+      for (let key in Http.INSTANCES) {
+        const instance = Http.INSTANCES[key];
+        instance.interceptors.response.use(resolve, reject);
+      }
     }
   }
 }
-

--- a/src/mlz_axios.ts
+++ b/src/mlz_axios.ts
@@ -5,24 +5,32 @@ import axios, {
   AxiosPromise,
   AxiosResponse,
   AxiosInstance
-} from 'axios';
+} from "axios";
 
-const DEFAULT_CONFIG:AxiosRequestConfig = {
+const DEFAULT_CONFIG: AxiosRequestConfig = {
   timeout: 5000,
   withCredentials: true,
-  validateStatus: (status) => status >= 200 && status < 599,
-}
+  validateStatus: status => status >= 200 && status < 599
+};
 
 export class Http {
-  private cancelToken: CancelTokenStatic = axios.CancelToken;
-  private source: CancelTokenSource = this.cancelToken.source();
-  private axiosIns: AxiosInstance;
+  private isSetInstancesToken: boolean = false;
 
-  static authorizationTypeKey:string = 'Authorization';
-  static authorizationTokenKey:string = 'authorization_type';
-  static authorizationType:number = 3;
-  static authorizationToken: string = "";
+  public cancelToken: CancelTokenStatic = axios.CancelToken;
+  public axiosIns: AxiosInstance;
+  public source: CancelTokenSource = this.cancelToken.source();
+  public authorizationTypeKey: string = "Authorization";
+  public authorizationTokenKey: string = "authorization_type";
+  public authorizationTypeValue: number;
+  public authorizationTokenValue: string = "";
+
+  static authorizationTypeKey: string = "Authorization";
+  static authorizationTokenKey: string = "authorization_type";
+  static authorizationTypeValue: number;
+  static authorizationTokenValue: string = "";
   static INSTANCES: { [key: string]: AxiosInstance } = {};
+  static INSTANCES_REQUEST_INTERCEPTORS: { [key: string]: number } = {};
+  static INSTANCES_RESPONSE_INTERCEPTORS: { [key: string]: number } = {};
 
   constructor(baseUrl: string, config: AxiosRequestConfig = {}) {
     const axiosIns = axios.create({
@@ -34,90 +42,141 @@ export class Http {
     this.axiosIns = axiosIns;
   }
 
+  public setInstancesAuthorizationTypeOrToken(
+    typeKey: string,
+    typeValue: number,
+    tokenKey: string,
+    tokenValue: string
+  ) {
+    this.isSetInstancesToken = true;
+    this.authorizationTypeKey = typeKey;
+    this.authorizationTokenKey = tokenKey;
+    this.authorizationTokenValue = tokenValue;
+    this.authorizationTypeValue = typeValue;
+  }
+
   private request(opt: AxiosRequestConfig) {
     const _opt = Object.assign({}, opt);
-    _opt.headers = {
-      ..._opt.headers,
-      [Http.authorizationTypeKey]: Http.authorizationType,
-      [Http.authorizationTokenKey]: Http.authorizationToken
-    };
+    if (this.isSetInstancesToken) {
+      _opt.headers = {
+        ..._opt.headers,
+        [this.authorizationTypeKey]: this.authorizationTypeValue,
+        [this.authorizationTokenKey]: this.authorizationTokenValue
+      };
+    } else {
+      _opt.headers = {
+        ..._opt.headers,
+        [Http.authorizationTypeKey]: Http.authorizationTypeValue,
+        [Http.authorizationTokenKey]: Http.authorizationTokenValue
+      };
+    }
     _opt.cancelToken = this.source.token;
     return this.axiosIns.request(_opt);
   }
 
   public abort() {
-    this.source.cancel('API abort.')
+    this.source.cancel("API abort.");
   }
-  public get(url:string, configs?:AxiosRequestConfig) {
+  public get(url: string, configs?: AxiosRequestConfig) {
     return this.request({
-      method: 'get',
+      method: "get",
       url,
-      ...configs,
+      ...configs
     });
   }
-  public post(url:string, data?:any, configs?:AxiosRequestConfig) : AxiosPromise {
+  public post(url: string, data?: any, configs?: AxiosRequestConfig): AxiosPromise {
     return this.request({
-      method: 'post',
+      method: "post",
       url,
       data,
-      ...configs,
-    })
+      ...configs
+    });
   }
-  public put(url:string, data?:any, configs?:AxiosRequestConfig) : AxiosPromise {
+  public put(url: string, data?: any, configs?: AxiosRequestConfig): AxiosPromise {
     return this.request({
-      method: 'put',
+      method: "put",
       url,
       data,
-      ...configs,
-    })
+      ...configs
+    });
   }
-  public patch(url:string, data?:any, configs?:AxiosRequestConfig) : AxiosPromise {
+  public patch(url: string, data?: any, configs?: AxiosRequestConfig): AxiosPromise {
     return this.request({
-      method: 'patch',
+      method: "patch",
       url,
       data,
-      ...configs,
-    })
+      ...configs
+    });
   }
-  public delete(url:string, configs?:AxiosRequestConfig) : AxiosPromise {
+  public delete(url: string, configs?: AxiosRequestConfig): AxiosPromise {
     return this.request({
-      method: 'delete',
+      method: "delete",
       url,
-      ...configs,
-    })
-  }
-  // 下面是静态方法
-  static setAuthorizationTypeOrToken(typeKey:string, typeValue:number, tokenKey:string, tokenValue:string) {
-    Http.authorizationTypeKey = typeKey;
-    Http.authorizationTokenKey = tokenKey;
-    Http.authorizationToken = tokenValue;
-    Http.authorizationType = typeValue;
+      ...configs
+    });
   }
 
-  static getInstances(key:string) : AxiosInstance {
+  // 下面是静态方法
+  static setAuthorizationTypeOrToken(
+    typeKey: string,
+    typeValue: number,
+    tokenKey: string,
+    tokenValue: string
+  ) {
+    Http.authorizationTypeKey = typeKey;
+    Http.authorizationTokenKey = tokenKey;
+    Http.authorizationTokenValue = tokenValue;
+    Http.authorizationTypeValue = typeValue;
+  }
+
+  static getInstances(key: string): AxiosInstance {
     return Http.INSTANCES[key];
   }
 
-  static setReqInterceptor (resolve?:(config:AxiosRequestConfig) => AxiosRequestConfig, reject?:(error:any) => void, key?:string) {
-    if(key) {
-      const instance = Http.INSTANCES[key];
-      instance.interceptors.request.use(resolve, reject);
+  static setReqInterceptor(
+    resolve?: (config: AxiosRequestConfig) => AxiosRequestConfig,
+    reject?: (error: any) => void,
+    url?: string
+  ) {
+    if (url) {
+      const interceptorsId = Http.INSTANCES_REQUEST_INTERCEPTORS[url];
+      const instance = Http.INSTANCES[url];
+      if (interceptorsId !== undefined) {
+        instance.interceptors.request.eject(interceptorsId);
+      }
+      const CreateInterceptorsId = instance.interceptors.request.use(resolve, reject);
+      Http.INSTANCES_REQUEST_INTERCEPTORS[url] = CreateInterceptorsId;
     } else {
       for (let key in Http.INSTANCES) {
-        const instance = Http.INSTANCES[key];
-        instance.interceptors.request.use(resolve, reject);
+        if (Http.INSTANCES_REQUEST_INTERCEPTORS[key] === undefined) {
+          const instance = Http.INSTANCES[key];
+          const interceptorsId = instance.interceptors.request.use(resolve, reject);
+          Http.INSTANCES_REQUEST_INTERCEPTORS[key] = interceptorsId;
+        }
       }
     }
   }
 
-  static setResInterceptor (resolve?:(res:AxiosResponse) => AxiosResponse, reject?:(error) => any, key?:string) {
-    if(key) {
-      const instance = Http.INSTANCES[key];
-      instance.interceptors.response.use(resolve, reject);
+  static setResInterceptor(
+    resolve?: (res: AxiosResponse) => AxiosResponse,
+    reject?: (error) => any,
+    url?: string
+  ) {
+    if (url) {
+      const interceptorsId = Http.INSTANCES_RESPONSE_INTERCEPTORS[url];
+      const instance = Http.INSTANCES[url];
+      if (interceptorsId !== undefined) {
+        instance.interceptors.response.eject(interceptorsId);
+      }
+      const CreateInterceptorsId = instance.interceptors.response.use(resolve, reject);
+      Http.INSTANCES_RESPONSE_INTERCEPTORS[url] = CreateInterceptorsId;
     } else {
       for (let key in Http.INSTANCES) {
-        const instance = Http.INSTANCES[key];
-        instance.interceptors.response.use(resolve, reject);
+        if (Http.INSTANCES_RESPONSE_INTERCEPTORS[key] === undefined) {
+          const instance = Http.INSTANCES[key];
+          const CreateInterceptorsId = instance.interceptors.response.use(resolve, reject);
+          Http.INSTANCES_RESPONSE_INTERCEPTORS[key] = CreateInterceptorsId;
+        }
       }
     }
   }


### PR DESCRIPTION
1. 支持设置单个实例拦截器
2. 静态方法全局设置token，这样就不用每个实例都设置一次token
3. 修复Object.assign(null, opt)opt无法覆盖至null问题，修改为Object.assign({}, opt)
4. 删除了post请求默认设置的'Content-type': 'application/x-www-form-urlencoded'，这在某些接口进行post请求时会发生报错，例如tiger和CRM接口。如果想设置Content-type，感觉在config中自己设置header更好